### PR TITLE
ADT logger for ADT console applications

### DIFF
--- a/src/zcl_alog_adt_logger.clas.abap
+++ b/src/zcl_alog_adt_logger.clas.abap
@@ -1,0 +1,65 @@
+"! Logger for ADT console applications
+"! <p>
+"! This logger dynamically uses the <em>OUT</em>-parameter of <em>IF_OO_ADT_CLASSRUN~MAIN</em> for
+"! log output. Static usage is intentionally avoided because the interface is only available as of
+"! ABAP 7.51.
+"! </p>
+"! Unfortunately there are some limitations if you expect Java-style console output. These seem to
+"! be 'by design':
+"! <ul>
+"!   <li>Logged output is only transmitted after the <em>main</em>-method has finished
+"!       execution</li>
+"!   <li>Logged output is not transmitted at all if the application fails with a short dump</li>
+"!   <li>Log entries are always separated by an empty line</li>
+"! </ul>
+CLASS zcl_alog_adt_logger DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_alog_msg_logger_base
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    METHODS:
+      "! @parameter io_out | Reference to <em>IF_OO_ADT_INTRNL_CLASSRUN</em> as found in
+      "!                     <em>IF_OO_ADT_CLASSRUN~MAIN</em>-OUT
+      "! @raising zcx_alog_argument_null | <em>io_out</em> cannot be null
+      "! @raising zcx_alog_illegal_argument | <em>io_out</em> does not implement
+      "!                                      <em>IF_OO_ADT_INTRNL_CLASSRUN</em>
+      constructor IMPORTING io_out TYPE REF TO object
+                  RAISING   zcx_alog_argument_null
+                            zcx_alog_illegal_argument.
+  PROTECTED SECTION.
+    METHODS:
+      entry_internal REDEFINITION.
+  PRIVATE SECTION.
+    METHODS:
+      format_entry IMPORTING iv_text             TYPE csequence
+                             io_type             TYPE REF TO zcl_alog_entry_type
+                   RETURNING VALUE(rv_formatted) TYPE string.
+    DATA:
+      mi_console_adapter TYPE REF TO lcl_adapter.
+ENDCLASS.
+
+
+
+CLASS zcl_alog_adt_logger IMPLEMENTATION.
+  METHOD constructor.
+    super->constructor( ).
+    mi_console_adapter = NEW lcl_adapter( io_out ).
+  ENDMETHOD.
+
+  METHOD entry_internal.
+    mi_console_adapter->write_text( format_entry( iv_text = iv_text io_type = io_type ) ).
+  ENDMETHOD.
+
+  METHOD format_entry.
+    DATA: lv_timestamp TYPE timestampl.
+
+    ASSERT io_type IS BOUND.
+    GET TIME STAMP FIELD lv_timestamp.
+    DATA(lv_timezone) = cl_abap_tstmp=>get_system_timezone( ).
+
+    rv_formatted = |{ lv_timestamp TIMESTAMP = ISO TIMEZONE = lv_timezone } | &&
+                   |{ io_type->mv_description WIDTH = 7 ALIGN = LEFT } | &&
+                   |{ iv_text }|.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_alog_adt_logger.clas.locals_def.abap
+++ b/src/zcl_alog_adt_logger.clas.locals_def.abap
@@ -1,0 +1,24 @@
+"! Internal adapter class for <em>IF_OO_ADT_INTRNL_CLASSRUN</em>
+CLASS lcl_adapter DEFINITION.
+  PUBLIC SECTION.
+    METHODS:
+      constructor IMPORTING io_out TYPE REF TO object
+                  RAISING   zcx_alog_argument_null
+                            zcx_alog_illegal_argument,
+      write IMPORTING ig_data TYPE any
+                      iv_name TYPE string OPTIONAL,
+      write_data IMPORTING ig_value TYPE data
+                           iv_name  TYPE string OPTIONAL,
+      write_text IMPORTING iv_text TYPE clike,
+      line,
+      begin_section IMPORTING iv_title TYPE clike OPTIONAL.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    CONSTANTS:
+      gc_out_intfname TYPE abap_intfname VALUE 'IF_OO_ADT_INTRNL_CLASSRUN'.
+    CLASS-METHODS:
+      get_full_method_name IMPORTING iv_method               TYPE abap_methname
+                           RETURNING VALUE(rv_full_methname) TYPE abap_methname.
+    DATA:
+      mo_out TYPE REF TO object.
+ENDCLASS.

--- a/src/zcl_alog_adt_logger.clas.locals_imp.abap
+++ b/src/zcl_alog_adt_logger.clas.locals_imp.abap
@@ -1,0 +1,57 @@
+CLASS lcl_adapter IMPLEMENTATION.
+  METHOD constructor.
+    IF io_out IS NOT BOUND.
+      RAISE EXCEPTION TYPE zcx_alog_argument_null
+        EXPORTING
+          iv_variable_name = 'IO_OUT'.
+    ENDIF.
+
+    DATA(lo_descr) = CAST cl_abap_classdescr( cl_abap_typedescr=>describe_by_object_ref( io_out ) ).
+    IF NOT line_exists( lo_descr->interfaces[ name = gc_out_intfname ] ).
+      RAISE EXCEPTION TYPE zcx_alog_illegal_argument
+        EXPORTING
+          iv_reason = |io_out does not implement '{ gc_out_intfname }'|.
+    ENDIF.
+
+    mo_out = io_out.
+  ENDMETHOD.
+
+  METHOD line.
+    DATA(lv_method) = get_full_method_name( 'LINE' ).
+    CALL METHOD mo_out->(lv_method).
+  ENDMETHOD.
+
+  METHOD write.
+    DATA(lv_method) = get_full_method_name( 'WRITE' ).
+    CALL METHOD mo_out->(lv_method)
+      EXPORTING
+        data = ig_data
+        name = iv_name.
+  ENDMETHOD.
+
+  METHOD write_data.
+    DATA(lv_method) = get_full_method_name( 'WRITE_DATA' ).
+    CALL METHOD mo_out->(lv_method)
+      EXPORTING
+        value = ig_value
+        name  = iv_name.
+  ENDMETHOD.
+
+  METHOD write_text.
+    DATA(lv_method) = get_full_method_name( 'WRITE_TEXT' ).
+    CALL METHOD mo_out->(lv_method)
+      EXPORTING
+        text = iv_text.
+  ENDMETHOD.
+
+  METHOD begin_section.
+    DATA(lv_method) = get_full_method_name( 'BEGIN_SECTION' ).
+    CALL METHOD mo_out->(lv_method)
+      EXPORTING
+        title = iv_title.
+  ENDMETHOD.
+
+  METHOD get_full_method_name.
+    rv_full_methname = |{ gc_out_intfname }~{ iv_method }|.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_alog_adt_logger.clas.xml
+++ b/src/zcl_alog_adt_logger.clas.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ALOG_ADT_LOGGER</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Logger for ADT console applications</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_alog_static_configuration.clas.abap
+++ b/src/zcl_alog_static_configuration.clas.abap
@@ -54,7 +54,9 @@ CLASS zcl_alog_static_configuration IMPLEMENTATION.
 
 
   METHOD constructor.
-    DATA: li_msg_logger TYPE REF TO zif_alog_msg_logger ##NEEDED.
+    CONSTANTS: lv_msg_internal_methname TYPE abap_methname VALUE 'ENTRY_MSG_INTERNAL'.
+    DATA: li_msg_logger TYPE REF TO zif_alog_msg_logger ##NEEDED,
+          lo_msg_base   TYPE REF TO zcl_alog_msg_logger_base ##NEEDED.
 
     IF ii_logger IS NOT BOUND.
       RAISE EXCEPTION TYPE zcx_alog_argument_null
@@ -62,12 +64,36 @@ CLASS zcl_alog_static_configuration IMPLEMENTATION.
           iv_variable_name = 'II_LOGGER'.
     ENDIF.
 
-    mv_supports_t100_msg = boolc( CAST cl_abap_objectdescr(
-                                    CAST cl_abap_refdescr(
-                                     cl_abap_typedescr=>describe_by_data( li_msg_logger )
-                                    )->get_referenced_type( )
-                                  )->applies_to( ii_logger ) ).
     mo_logger_descr = CAST #( cl_abap_typedescr=>describe_by_object_ref( ii_logger ) ).
+
+    DATA(lv_implements_msg) = CONV abap_bool( boolc(
+                                CAST cl_abap_objectdescr(
+                                  CAST cl_abap_refdescr(
+                                   cl_abap_typedescr=>describe_by_data( li_msg_logger )
+                                  )->get_referenced_type( )
+                                )->applies_to( ii_logger ) ) ).
+    DATA(lo_msg_base_descr) = CAST cl_abap_classdescr(
+                                CAST cl_abap_refdescr(
+                                  cl_abap_typedescr=>describe_by_data( lo_msg_base )
+                                )->get_referenced_type( )
+                              ).
+    IF lo_msg_base_descr->applies_to( ii_logger ) = abap_true.
+      DATA(lv_overrides_msg) = CONV abap_bool( boolc( line_exists(
+                                 mo_logger_descr->methods[
+                                   is_redefined = abap_true
+                                   is_inherited = abap_true
+                                   name         = lv_msg_internal_methname
+                                 ]
+                               ) ) ).
+    ENDIF.
+
+    " Native T100 message support means implementing ZIF_ALOG_MSG_LOGGER and either not having
+    " ZCL_ALOG_MSG_LOGGER_BASE as a base class or redefining MSG_ENTRY_INTERNAL. These additional
+    " checks are needed, because otherwise the fallback implementation of the logger base class
+    " will prevent the potential prefix to be added to the log entry even though messages aren't
+    " handled natively at all.
+    mv_supports_t100_msg = boolc( lv_implements_msg = abap_true AND lv_overrides_msg = abap_true ).
+
     mi_logger = ii_logger.
     mv_with_prefix = iv_with_prefix.
   ENDMETHOD.

--- a/src/zcl_alog_static_logger.clas.abap
+++ b/src/zcl_alog_static_logger.clas.abap
@@ -25,7 +25,7 @@ CLASS zcl_alog_static_logger DEFINITION
       "! @parameter ri_msg_logger | Logger instance
       get_msg_logger IMPORTING iv_prefix            TYPE csequence OPTIONAL
                      RETURNING VALUE(ri_msg_logger) TYPE REF TO zif_alog_msg_logger,
-      "! Get a prefixed logger for a variablle
+      "! Get a prefixed logger for a variable
       "! @parameter ig_any | Variable whose relative type name will be the logger prefix
       "! @parameter ri_msg_logger | Message logger instance
       get_msg_logger_for_any IMPORTING ig_any               TYPE any


### PR DESCRIPTION
Fixes #12

Examples cannot be added in the repository because they would not compile on < 7.51. They need to be added to the wiki or something like that.