### PR TITLE
Fix `Method "GET_SYSTEM_TIMEZONE" is unknown or PROTECTED or PRIVATE.`

### DIFF
--- a/src/zcl_alog_adt_logger.clas.abap
+++ b/src/zcl_alog_adt_logger.clas.abap
@@ -52,11 +52,15 @@ CLASS zcl_alog_adt_logger IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD format_entry.
-    DATA: lv_timestamp TYPE timestampl.
+    DATA:
+      lv_timestamp TYPE timestampl,
+      lv_timezone  TYPE timezone.
 
     ASSERT io_type IS BOUND.
     GET TIME STAMP FIELD lv_timestamp.
-    DATA(lv_timezone) = cl_abap_tstmp=>get_system_timezone( ).
+    CALL FUNCTION 'GET_SYSTEM_TIMEZONE'
+      IMPORTING
+        timezone = lv_timezone.
 
     rv_formatted = |{ lv_timestamp TIMESTAMP = ISO TIMEZONE = lv_timezone } | &&
                    |{ io_type->mv_description WIDTH = 7 ALIGN = LEFT } | &&


### PR DESCRIPTION
We can't transport this library because we get a syntax error:
`Method "GET_SYSTEM_TIMEZONE" is unknown or PROTECTED or PRIVATE.`

I could not find any documentation on `cl_abap_tstmp=>get_system_timezone`.
So i replaced this as described in the [ABAP reference](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abensystem_user_time_zones.htm) with the FuBa `GET_SYSTEM_TIMEZONE`